### PR TITLE
Fix rank range check

### DIFF
--- a/tensorrt_llm/mapping.py
+++ b/tensorrt_llm/mapping.py
@@ -301,8 +301,7 @@ class Mapping(object):
     def rank(self, rank: int):
         # TODO(qijun): skip check for enable_attention_dp temporarily, will support attention_dp_size
         if not self.enable_attention_dp:
-            if not isinstance(rank,
-                              int) or rank < 0 and rank >= self.world_size:
+            if not isinstance(rank, int) or rank < 0 or rank >= self.world_size:
                 raise ValueError(
                     f"Rank should be an integer between 0 and {self.world_size-1}, but got {rank}."
                 )


### PR DESCRIPTION
## Summary
- fix rank validation logic in `Mapping.rank`

## Testing
- `python -m py_compile tensorrt_llm/mapping.py`
- `PYTHONPATH=. pytest tests/unittest/others/test_mapping.py -q` *(fails: ModuleNotFoundError: No module named 'tensorrt')*

------
https://chatgpt.com/codex/tasks/task_e_683f79d4ff388322af1c72b2d43347ad